### PR TITLE
Where booleans WINDOWS, etc are bound.  See #94

### DIFF
--- a/pep-0484.txt
+++ b/pep-0484.txt
@@ -567,7 +567,9 @@ module to enable platform-specific type definitions and such::
   else:
       loop = UnixSelectorEventLoop
 
-It is up to the type checker implementation to define their values, as
+Note that a type checker implementation may provide its own execution
+environment, with different values bound to these names.  It is up to 
+the type checker implementation to define their values, as
 long as ``PY2 == not PY3`` and ``WINDOWS == not POSIX``.  When the
 program is being executed these always reflect the current platform,
 and this is also the suggested default when the program is being


### PR DESCRIPTION
In issue #94 I asked for clarification on how checkers could be responsible for the values if they were in the typing module.  This tries to capture Guido's answer.
